### PR TITLE
Prevent loadUserByUsername from returning null

### DIFF
--- a/src/main/java/ru/ifmo/neerc/volunteers/controller/LoginController.java
+++ b/src/main/java/ru/ifmo/neerc/volunteers/controller/LoginController.java
@@ -45,10 +45,9 @@ public class LoginController {
                         @RequestParam(value = "reset", required = false) final String reset,
                         final Model model) {
 
-        if (error != null) {
-            model.addAttribute("error", "");
-            model.addAttribute("resetPasswordForm", new EmailForm());
-        }
+        model.addAttribute("error", error);
+        model.addAttribute("resetPasswordForm", new EmailForm());
+
         /*if (logout != null) {
             model.addAttribute("message", "");
         }*/
@@ -107,7 +106,7 @@ public class LoginController {
     @GetMapping(value = "/confirm")
     public String confirmEmail(@RequestParam("id") final long id, @RequestParam("email") final String email, HttpServletResponse resp) throws IOException {
         User user = userRepository.findOne(id);
-        if (user ==null) {
+        if (user == null) {
             log.warn("User with id={} is not found", id);
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return null;

--- a/src/main/java/ru/ifmo/neerc/volunteers/service/UserDetailsServiceImpl.java
+++ b/src/main/java/ru/ifmo/neerc/volunteers/service/UserDetailsServiceImpl.java
@@ -18,14 +18,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
-        UserDetails userDetails;
-        try {
-            userDetails = userRepository.findByEmailIgnoreCase(username);
-            /*new org.springframework.security.core.userdetails.User(
-                    username, user.getPassword(), user.getAuth()
-            );*/
-        } catch (final Exception e) {
-            throw new UsernameNotFoundException(e.getMessage(), e);
+        UserDetails userDetails = userRepository.findByEmailIgnoreCase(username);
+        if (userDetails == null) {
+            throw new UsernameNotFoundException("Username " + username + " not found");
         }
 
         return userDetails;

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -13,7 +13,7 @@ volunteers.login.password=Password
 volunteers.login.login=Log in
 volunteers.login.signUp=Sign up
 volunteers.login.passwordReset=Reset password
-volunteers.login.passwordReset.success=Check you email
+volunteers.login.passwordReset.success=Check your email
 volunteers.login.passwordReset.error.unknowEmail=Unknown email
 volunteers.login.passwordReset.changed=Your password changed
 # Error page

--- a/src/main/webapp/WEB-INF/view/login.html
+++ b/src/main/webapp/WEB-INF/view/login.html
@@ -26,14 +26,13 @@
         <div class="form-group">
             <button type="submit" class="btn btn-default" th:text="#{volunteers.login.login}">Log in</button>
             <button type="button" class="btn btn-link" role="button" th:text="#{volunteers.login.passwordReset}"
-                    th:if="${error!=null}" data-toggle="modal" data-target="#resetPasswordModal">Reset password
+                    data-toggle="modal" data-target="#resetPasswordModal">Reset password
             </button>
             <a th:href="@{/signup}" class="btn btn-link" role="button" th:text="#{volunteers.login.signUp}">Sign up</a>
         </div>
     </form>
 
-    <div class="modal fade" id="resetPasswordModal" tabindex="-1" role="dialog" aria-labelledby="label"
-         th:if="${error}">
+    <div class="modal fade" id="resetPasswordModal" tabindex="-1" role="dialog" aria-labelledby="label">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <form th:object="${resetPasswordForm}" id="resetPasswordForm">


### PR DESCRIPTION
Exception is thrown every time someone tries to login with a wrong email.
`org.springframework.security.authentication.InternalAuthenticationServiceException: UserDetailsService returned null, which is an interface contract violation`